### PR TITLE
bugfix/copy to clipboard button color

### DIFF
--- a/wordle-helper.js
+++ b/wordle-helper.js
@@ -766,10 +766,11 @@ function getShareLink() {
 }
 
 function animateCopy(element) {
+  let origBackgroundColor = element.css("background-color");
   element.css("background-color", "green");
   element.text("Copied! ✔");
   setTimeout(function () {
-    element.css("background-color", "#0B5ED7");
+    element.css("background-color", origBackgroundColor);
     element.text("Copy to Clipboard");
   }, 2000);
   element.blur();


### PR DESCRIPTION
allow the original color of the "copy to clipboard" button to be retained after clicking